### PR TITLE
Make logos clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Learn more about the story of this project at the links below:
 
 Haven was developed through a collaboration between [Freedom of the Press Foundation](https://freedom.press) and [Guardian Project](https://guardianproject.info). Prototype funding was generously provided by FoPF, and donations to support continuing work can be contributed through their site: https://freedom.press/donate-support-haven-open-source-project/
 
-![Freedom of the Press Foundation](https://raw.githubusercontent.com/guardianproject/haven/master/art/logos/fopflogo.png)
-![Guardian Project](https://raw.githubusercontent.com/guardianproject/haven/master/art/logos/gplogo.png)
+[![Freedom of the Press Foundation](https://raw.githubusercontent.com/guardianproject/haven/master/art/logos/fopflogo.png)](https://freedom.press)
+[![Guardian Project](https://raw.githubusercontent.com/guardianproject/haven/master/art/logos/gplogo.png)](https://guardianproject.info)
 
 ## Safety through Sensors
 


### PR DESCRIPTION
While reading the readme I went to click on the logos of the two sponsors and was surprised they didn't work. I found the links in the text, but I suspect people would expect the logos to be links as well.